### PR TITLE
Use Haskell-Language-Server instead of Haskell-Ide-Engine

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,6 +6,5 @@
   "files.insertFinalNewline": true,
 
   "haskell.indentationRules.enabled": true,
-  "languageServerHaskell.useCustomHieWrapper": true,
-  "languageServerHaskell.useCustomHieWrapperPath": "${workspaceRoot}/bin/hie-wrapper"
+  "haskell.serverExecutablePath": "${workspaceRoot}/bin/hls-wrapper"
 }

--- a/README.md
+++ b/README.md
@@ -6,9 +6,8 @@ with some of the fiddly bits taken care of for you, while providing a featureful
 ## Features
 
 * Nix based build and dev environment
-  * **NB:** [Adding the `all-hies` cache to your nix configuration](https://github.com/Infinisil/all-hies#cached-builds) is strongly recommended, using [cachix](https://github.com/cachix/cachix) you can run `cachix use all-hies` to get set up.
 * Lots of tooling! 🔨
-  * [Haskell-Ide-Engine](https://github.com/haskell/haskell-ide-engine), and VS-Code integration, just install the [Haskell Language Server extension](https://marketplace.visualstudio.com/items?itemName=alanz.vscode-hie-server)
+  * [Haskell Language Server](https://github.com/haskell/haskell-language-server), and VS-Code integration, just install the [Haskell extension](https://marketplace.visualstudio.com/items?itemName=haskell.haskell)
   * [GHCiD](https://github.com/ndmitchell/ghcid)
   * [Hoogle](https://github.com/ndmitchell/hoogle)
   * [And more!](shell.nix)
@@ -21,7 +20,6 @@ with some of the fiddly bits taken care of for you, while providing a featureful
         * config.nix
         * default.nix
         * haskell-starter-webservice.cabal
-        * haskell-starter-webservice.nix
         * README.md
     * You will also need to rename the following files
         * haskell-starter-webservice.cabal -> my-awesome-ws.cabal

--- a/bin/hie-wrapper
+++ b/bin/hie-wrapper
@@ -1,3 +1,0 @@
-#! /bin/sh
-
-nix-shell --command "hie --lsp"

--- a/bin/hls-wrapper
+++ b/bin/hls-wrapper
@@ -1,0 +1,3 @@
+#! /bin/sh
+
+nix-shell --command "haskell-language-server $@"

--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -1,8 +1,3 @@
-# This is a sample build configuration for Other.
-# Check our guides at https://confluence.atlassian.com/x/5Q4SMw for more examples.
-# Only use spaces to indent your .yml configuration.
-# -----
-# You can specify a custom docker image from Docker Hub as your build environment.
 image: nixos/nix:2.1.3
 
 pipelines:

--- a/config.nix
+++ b/config.nix
@@ -1,6 +1,12 @@
 rec {
   # Which version of GHC does the project need to be built with? This must exist in both nixpkgs, and hie-nix
   ghcVersion = "ghc865";
+  languageServerGHCVersion = "8.6.5";
+
+  # Pick a release version from https://github.com/haskell/haskell-language-server/releases
+  # Double check to make sure it's available in https://github.com/masaeedu/all-hls/blob/master/sources.json
+  languageServerVersion = "0.4.0";
+
   # Bootstrap the ability to fetch from GitHub
   fetchFromGitHub = (import <nixpkgs> {}).fetchFromGitHub;
 
@@ -24,11 +30,11 @@ rec {
       sha256 = "0kaazqda1saaasyd2dg3zz2zwag36555x981znplq4fq85brval5";
     };
 
-    all-hies = {
-      owner = "Infinisil";
-      repo = "all-hies";
-      rev = "9214868";
-      sha256 = "1yb75f8p09dp4yx5d3w3wvdiflaav9a5202xz9whigk2p9ndwbp5";
+    all-hls = {
+      owner = "masaeedu";
+      repo = "all-hls";
+      rev = "155e57d7ca9f79ce293360f98895e9bd68d12355";
+      sha256 = "04s3mrxjdr7gmd901l1z23qglqmn8i39v7sdf2fv4zbv6hz24ydb";
     };
   };
 
@@ -46,6 +52,13 @@ rec {
     };
   };
 
-  # Pick a version of HIE that is compatible with our version of GHC.
-  hie = (import (fetchFromGitHub repos.all-hies) { }).versions.${ghcVersion};
+  # Make sure we're getting the right version of the Haskell-Language server for our GHC version and our Operating System
+  haskellLanguageServer = let
+          platform = if builtins.currentSystem == "x86_64-darwin" then "MacOS" else "Linux";
+        in (import (fetchFromGitHub repos.all-hls) {
+          pkgs = nixpkgs;
+          platform = platform;
+          version = languageServerVersion;
+          ghc = languageServerGHCVersion;
+        });
 }

--- a/server/Main.hs
+++ b/server/Main.hs
@@ -17,12 +17,11 @@ main = do
   run 8081 application
 
 
--- Create handlers for serving our API
+-- |Create handlers for serving our API
 greetingHandler :: Server GreetingAPI
 greetingHandler name = do
   forkMsg <- liftIO $ do
-    let req = getRepository (UserName name) (RepositoryName "haskell-starter-webservice")
-    res <- mkGitHubRequest req
+    res <- mkGitHubRequest getHaskellStarterRepo
     print res
     pure $ either (const "You haven't forked the repo on GitHub.") (const "You forked the repo!") res
   pure $ Greeting $ "Hi " ++ show name ++ "! " ++ forkMsg

--- a/shell.nix
+++ b/shell.nix
@@ -4,5 +4,5 @@ in with config; hpkgs.shellFor {
   packages = p: [drv];
   # You can add any tools here that you would like to be available within a nix-shell. Hakell-Ide-Engine is started within
   #  a nix-shell automatically in VS-Code.
-  buildInputs = with nixpkgs; [ hie cabal-install hlint hpkgs.ghcid hpkgs.hasktags hpkgs.hoogle ];
+  buildInputs = with nixpkgs; [ haskellLanguageServer cabal-install hlint hpkgs.ghcid hpkgs.hasktags hpkgs.hoogle ];
 }


### PR DESCRIPTION
Udpated the docs too.

Unfortunately it seems like there's no well-regarded place to source nix-packaged Haskell-Language-Server binaries from, and I can't set up Haskell-Language-Server to try and retrieve the binaries itself from inside a nix-shell. I'm also not keen on dragging in all the cruft of self-managing it inside this project.

Oh well 🤷‍♂️

`docserver` doesn't get tooling for some reason. I might end up needing to roll it in to the main `server` target.